### PR TITLE
Fix nation screen rounding issues

### DIFF
--- a/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
+++ b/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
@@ -99,7 +99,7 @@ public class NationEventListener implements Listener {
 			}
 
 			// Sort the map from strongest culture to weakest culture.
-			mainCulturePercentageInteger = sortMap(cultureStrength);
+			mainCulturePercentageInteger = sortMap(mainCulturePercentageInteger);
 
 			// Turn it into a list of "Culturename ###%" strings.
 			List<String> cultures = new ArrayList<>(mainCulturePercentageInteger.size());

--- a/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
+++ b/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
@@ -28,91 +28,56 @@ public class NationEventListener implements Listener {
 	@EventHandler
 	public void onNationStatus(NationStatusScreenEvent event) {
 		if (TownyCulturesSettings.isTownyCulturesEnabled()) {
-
-			//Get total nation population
-			double totalNationPopulation = event.getNation().getNumResidents();
-
+			
 			/*
 			 * Create a map of cultures within the nation, from which the town
 			 * populations are used to calculate the strength of the culture.
 			 */
 			Map<String,Integer> cultureStrength = new HashMap<>();
 			for (Town town : event.getNation().getTowns())
-				assignStrength(town, cultureStrength);
+				assignStrength(town, town.getNumResidents(), cultureStrength);
 
 			/*
-			 * Create a double map of culture percentages
+			 * Create a double map of culture percentages, filtering out <1% to "Other".
 			 */
-			Map<String,Double> culturePercentageDouble = new HashMap<>();
-			for (Map.Entry<String, Integer> entry: cultureStrength.entrySet()) {
-				double percentDouble = ((double)entry.getValue()) / totalNationPopulation * 100;
-				culturePercentageDouble.put(entry.getKey(), percentDouble);
-			}
+			Map<String,Double> cultureDoubleMap = new HashMap<>();
+			for (Map.Entry<String, Integer> entry: cultureStrength.entrySet())
+				assignPercent(entry.getKey(), entry.getValue(), event.getNation().getNumResidents(), cultureDoubleMap);
 
 			/*
-			 * Create a double map of the main cultures only
-			 * i.e. for cultures of less than 1%, combine them as "Other"
+			 * Create an int map of culture percentages, adding 0.5 to effectively
+			 * round up instead of down if the % ends in a number greater than .5.
 			 */
-			Map<String,Double> mainCulturePercentageDouble = new HashMap<>();
-			for (Map.Entry<String, Double> entry: culturePercentageDouble.entrySet()) {
-				if(entry.getValue() < 1) {
-					if(mainCulturePercentageDouble.containsKey("Other")) {
-						double newPercentage = mainCulturePercentageDouble.get("Other") + entry.getValue();
-						mainCulturePercentageDouble.put("Other", newPercentage);
-					} else {
-						mainCulturePercentageDouble.put("Other", entry.getValue());
-					}
-				} else {
-					mainCulturePercentageDouble.put(entry.getKey(), entry.getValue());
-				}
-			}
-
-			/*
-			 * Create an int map of culture percentages
-			 */
-			Map<String,Integer> mainCulturePercentageInteger = new HashMap<>();
-			for (Map.Entry<String, Double> entry: mainCulturePercentageDouble.entrySet()) {
-				mainCulturePercentageInteger.put(entry.getKey(), (int) (entry.getValue() + 0.5)); //Round half up
-			}
+			Map<String,Integer> cultureIntegerMap = new HashMap<>();
+			for (Map.Entry<String, Double> entry: cultureDoubleMap.entrySet())
+				cultureIntegerMap.put(entry.getKey(), (int) (entry.getValue() + 0.5)); //Round half up
 
 			/*
 			 * Check if the percentages add up to 100% at this point. If not:
 			 * - assign the remainder to the capital city if it has a culture, or
 			 * - prescribe it as an unknown.
+			 * Remainder can be positive or negative but will always result in an even 100%.
 			 */
-			int totalCulturePercent = 0;
-			for(int individualCulturePercent: mainCulturePercentageInteger.values()) {
-				totalCulturePercent += individualCulturePercent;
-			}
-			int remainder = 100 - totalCulturePercent;
-			if(remainder != 0) {
-				Town capital = event.getNation().getCapital();
-				String capitalCulture;
-				int updatedPercent;
-				if (TownMetaDataController.hasTownCulture(capital)) {
-					capitalCulture = TownMetaDataController.getTownCulture(capital);
-				} else {
-					capitalCulture = "Unknown";
-				}
-				updatedPercent = mainCulturePercentageInteger.get(capitalCulture) + remainder;
-				mainCulturePercentageInteger.put(capitalCulture, updatedPercent);
-			}
+			int remainder = 100 - cultureIntegerMap.values().stream().reduce(0, Integer::sum); // 100 - sum of values()
+			if (remainder != 0) 
+				assignStrength(event.getNation().getCapital(), remainder, cultureIntegerMap);
 
-			// Sort the map from strongest culture to weakest culture.
-			mainCulturePercentageInteger = sortMap(mainCulturePercentageInteger);
+			/*
+			 * Sort the map from strongest culture to weakest culture.
+			 */
+			if (cultureIntegerMap.size() > 1)
+				cultureIntegerMap = sortMap(cultureIntegerMap);
 
-			// Turn it into a list of "Culturename ###%" strings.
-			List<String> cultures = new ArrayList<>(mainCulturePercentageInteger.size());
-			for (Map.Entry<String, Integer> entry: mainCulturePercentageInteger.entrySet()) {
+			/*
+			 * Turn it into a list of "Culturename ###%" strings.
+			 */
+			List<String> cultures = new ArrayList<>(cultureIntegerMap.size());
+			for (Map.Entry<String, Integer> entry: cultureIntegerMap.entrySet())
 				cultures.add(StringMgmt.capitalize(entry.getKey()) + " " + entry.getValue() + "%");
-			}
 
-			// Join the above lines if needed.
-			String output = "";
-			if (cultures.size() > 1)
-				output = String.join(", ", cultures);
-			else 
-				output = cultures.get(0);
+			String output = cultures.get(0);
+			if (cultures.size() > 1)                  // Join the lines if  
+				output = String.join(", ", cultures); // there's more than one.
 			
 			// Add our line to the NationStatusScreenEvent.
 			event.addLines(Arrays.asList(Translation.of("status_town_culture", output)));
@@ -120,24 +85,35 @@ public class NationEventListener implements Listener {
 	}
 
 	/*
-	 * Assigns the strength to the Town's culture or to the "Unknown" category.
+	 * Assigns the strength to the given Town's culture or to the "Unknown" category.
 	 */
-	private void assignStrength(Town town, Map<String, Integer> cultureStrength) {
-		String culture;
-		if (TownMetaDataController.hasTownCulture(town))
+	private void assignStrength(Town town, int strength, Map<String, Integer> cultureStrength) {
+		String culture = "Unknown";
+		if (TownMetaDataController.hasTownCulture(town)) // If the town has a culture, use that instead.
 			culture = TownMetaDataController.getTownCulture(town);
-		else 
-			culture = "Unknown";
 
-		if (cultureStrength.containsKey(culture)) {
-			//Culture already exists. Add the town population to it
-			cultureStrength.put(culture, cultureStrength.get(culture) + town.getNumResidents());
-		} else {
-			//Culture does not already exist. Create it
-			cultureStrength.put(culture, town.getNumResidents());
-		}
+		if (cultureStrength.containsKey(culture)) // Culture already exists in the map. Add the strength to it.
+			strength += cultureStrength.get(culture);
+
+		cultureStrength.put(culture, strength);
 	}
 
+	/*
+	 * Assigns the percentage strength for a Nation's culture, filtering <1% to "Other".
+	 */
+	private void assignPercent(String culture, int value, int nationPop, Map<String, Double> cultureStrength) {
+		double percent = ((double)value) / nationPop * 100;
+		if (percent < 1)       // Change culture over to 
+			culture = "Other"; // "Other" if less than 1%.
+		if (cultureStrength.containsKey(culture))    // If culture is already present,
+			percent += cultureStrength.get(culture); // add new strength to it.
+		
+		cultureStrength.put(culture, percent); // Place culture and strength into double map.
+	}
+
+	/*
+	 * Sorts a nation's cultures into largest -> smallest based on their %.
+	 */
 	private Map<String, Integer> sortMap(Map<String, Integer> cultureStrength) {
 		
         List<Map.Entry<String, Integer>> list = new LinkedList<Map.Entry<String, Integer>>(cultureStrength.entrySet());

--- a/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
+++ b/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
@@ -138,15 +138,6 @@ public class NationEventListener implements Listener {
 		}
 	}
 
-	private int findRemainder(double pop, Map<String, Integer> cultureStrength) {
-		int remainder = 100;
-		for (String culture : cultureStrength.keySet()) {
-			int percent = (int) (cultureStrength.get(culture) / pop * 100);
-			remainder -= percent;
-		}
-		return remainder;
-	}
-
 	private Map<String, Integer> sortMap(Map<String, Integer> cultureStrength) {
 		
         List<Map.Entry<String, Integer>> list = new LinkedList<Map.Entry<String, Integer>>(cultureStrength.entrySet());

--- a/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
+++ b/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
@@ -87,7 +87,7 @@ public class NationEventListener implements Listener {
 			for(int individualCulturePercent: mainCulturePercentageInteger.values()) {
 				totalCulturePercent += individualCulturePercent;
 			}
-			int remainder = totalCulturePercent - 100;
+			int remainder = 100 - totalCulturePercent;
 			if(remainder != 0) {
 				Town capital = event.getNation().getCapital();
 				String capitalCulture;

--- a/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
+++ b/src/main/java/com/gmail/goosius/townycultures/listeners/NationEventListener.java
@@ -40,14 +40,11 @@ public class NationEventListener implements Listener {
 			for (Town town : event.getNation().getTowns())
 				assignStrength(town, cultureStrength);
 
-			// Sort the map from strongest culture to weakest culture.
-			Map<String, Integer> sortedCultureStrengthMap = sortMap(cultureStrength);
-
 			/*
 			 * Create a double map of culture percentages
 			 */
 			Map<String,Double> culturePercentageDouble = new HashMap<>();
-			for (Map.Entry<String, Integer> entry: sortedCultureStrengthMap.entrySet()) {
+			for (Map.Entry<String, Integer> entry: cultureStrength.entrySet()) {
 				double percentDouble = ((double)entry.getValue()) / totalNationPopulation * 100;
 				culturePercentageDouble.put(entry.getKey(), percentDouble);
 			}
@@ -100,6 +97,9 @@ public class NationEventListener implements Listener {
 				updatedPercent = mainCulturePercentageInteger.get(capitalCulture) + remainder;
 				mainCulturePercentageInteger.put(capitalCulture, updatedPercent);
 			}
+
+			// Sort the map from strongest culture to weakest culture.
+			mainCulturePercentageInteger = sortMap(cultureStrength);
 
 			// Turn it into a list of "Culturename ###%" strings.
 			List<String> cultures = new ArrayList<>(mainCulturePercentageInteger.size());


### PR DESCRIPTION
#### Description: 
- Fixed the rounding issues on the nation screen
  - Cultures with a real percent of less than 1 will be merged for display into a culture of "Other"
  - Any difference in overall nation percent from 100, will be applied to the capital culture (whether it be set or "Unknown")
  
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
