### PR TITLE
Dynmap towny culture info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>TownyCultures</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>townycultures</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>TownyCultures</artifactId>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
   <name>townycultures</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>dynmap-api</artifactId>
       <version>2.5</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.TownyAdvanced</groupId>
+      <artifactId>Dynmap-Towny</artifactId>
+      <version>0.85</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/gmail/goosius/townycultures/TownyCultures.java
+++ b/src/main/java/com/gmail/goosius/townycultures/TownyCultures.java
@@ -1,6 +1,7 @@
 package com.gmail.goosius.townycultures;
 
 import com.gmail.goosius.townycultures.command.*;
+import com.gmail.goosius.townycultures.listeners.TownyDynmapListener;
 import com.gmail.goosius.townycultures.settings.TownyCulturesSettings;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
@@ -73,6 +74,7 @@ public class TownyCultures extends JavaPlugin {
 		PluginManager pm = Bukkit.getServer().getPluginManager();
 		pm.registerEvents(new TownEventListener(), this);
 		pm.registerEvents(new NationEventListener(), this);
+		pm.registerEvents(new TownyDynmapListener(), this);
 	}
 	
 	private void registerCommands() {

--- a/src/main/java/com/gmail/goosius/townycultures/listeners/TownyDynmapListener.java
+++ b/src/main/java/com/gmail/goosius/townycultures/listeners/TownyDynmapListener.java
@@ -1,0 +1,28 @@
+package com.gmail.goosius.townycultures.listeners;
+
+import com.gmail.goosius.townycultures.metadata.TownMetaDataController;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.dynmap.towny.events.BuildTownMarkerDescriptionEvent;
+
+public class TownyDynmapListener implements Listener {
+
+    /**
+     * This method updates the town popup box on Dynmap-Towny
+     *
+     * 1. It looks for the %culture% tag in the popup
+     * 2. If the %culture% tag exists, it replaces it with the town culture (or blank if there is no town culture)
+     */
+    @EventHandler
+    public void on(BuildTownMarkerDescriptionEvent event) {
+            if (event.getDescription().contains("%culture%")) {
+                String finalDescription;
+                    if (TownMetaDataController.hasTownCulture(event.getTown())) {
+                        finalDescription = event.getDescription().replace("%culture%", TownMetaDataController.getTownCulture(event.getTown()));
+                    } else {
+                        finalDescription = event.getDescription().replace("%culture%", "");
+                    }
+                event.setDescription(finalDescription);
+        }
+    }
+}


### PR DESCRIPTION
#### Description: 
- With current code, the towny dynmap cannot display the culture in the town popup
- With this PR, it can now be done, just by the admin putting '%culture%' in their popup config

____
#### New Nodes/Commands/ConfigOptions: 
N/A

____
#### Relevant Issue ticket:
N/A

____
- [x] I have tested this pull request for defects on a server. 

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the Towny [License](https://github.com/LlmDl/Towny/blob/master/LICENSE.md) for perpetuity.
